### PR TITLE
Add some primitive memory safety checks before ELF relocation

### DIFF
--- a/module_loader/Makefile
+++ b/module_loader/Makefile
@@ -2,6 +2,7 @@ OBJS=\
 bootstrap.o \
 module_loader.o \
 elf.o \
+addr_checker.o \
 long_load.o
 
 loader.elf: module_loader.ld $(OBJS)

--- a/module_loader/addr_checker.c
+++ b/module_loader/addr_checker.c
@@ -3,10 +3,55 @@
 #include "stdint.h"
 #include "addr_checker.h"
 
+size_t strlen(const char *c) {
+  size_t len = 0;
+  while (c[len] != 0) {
+    ++len;
+  }
+  return len;
+}
+
+bool check_MIS(const uint64_t load_addr, const MIS *mis) {
+  return load_addr > ((uint64_t)mis + (uint64_t)sizeof(MIS));
+}
+
+bool check_cmdline(const uint64_t load_addr, const MIS *mis) {
+  const char *cmdline = get_cmdline(mis);
+  const size_t len = strlen(cmdline);
+  return load_addr > ((uint64_t)cmdline + (uint64_t)len + 1ULL);
+}
+
+bool check_mod(const uint64_t load_addr, const Mod *mod) {
+  // check the module data
+  if (load_addr <= (uint64_t)(get_mod_end(mod))) {
+    return false;
+  }
+
+  // check the Mod structure
+  if (load_addr <= ((uint64_t)mod + (uint64_t)sizeof(Mod))) {
+    return false;
+  }
+
+  // check the Mod string
+  const char *s = get_mod_string(mod);
+  const size_t len = strlen(s);
+  return load_addr > ((uint64_t)s + (uint64_t)len);
+}
+
+bool check_mods(const uint64_t load_addr, const MIS *mis) {
+  const Mod *mods = get_mods(mis);
+  for (size_t i = 1; i < mis->mods_count; ++i) {
+    if (!check_mod(load_addr, &mods[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
 // check_all runs all of the address checking functions to ensure that
 // the target load address is above all of the structures loaded by
 // GRUB. If this returns true, then the load address is safe and will
 // not clobber any of GRUB's or the module loader's structures.
-bool check_all(uint64_t load_addr) {
-  return false;
+bool check_all(const uint64_t load_addr, const MIS *mis) {
+  return check_mods(load_addr, mis) && check_MIS(load_addr, mis) && check_cmdline(load_addr, mis);
 }

--- a/module_loader/addr_checker.c
+++ b/module_loader/addr_checker.c
@@ -11,6 +11,12 @@ size_t strlen(const char *c) {
   return len;
 }
 
+// TODO: modify these functions to return the highest address
+// found. This will be useful for the future when we want to use
+// paging to relocate the kernel instead of physically relocating
+// it. This information can be used to help us find free page frames
+// for allocating any "no data" sections (e.g. .bss)
+
 bool check_MIS(const uint64_t load_addr, const MIS *mis) {
   return load_addr > ((uint64_t)mis + (uint64_t)sizeof(MIS));
 }
@@ -18,7 +24,7 @@ bool check_MIS(const uint64_t load_addr, const MIS *mis) {
 bool check_cmdline(const uint64_t load_addr, const MIS *mis) {
   const char *cmdline = get_cmdline(mis);
   const size_t len = strlen(cmdline);
-  return load_addr > ((uint64_t)cmdline + (uint64_t)len + 1ULL);
+  return load_addr > ((uint64_t)cmdline + (uint64_t)len);
 }
 
 bool check_mod(const uint64_t load_addr, const Mod *mod) {

--- a/module_loader/addr_checker.c
+++ b/module_loader/addr_checker.c
@@ -1,0 +1,12 @@
+#include "stdbool.h"
+#include "stddef.h"
+#include "stdint.h"
+#include "addr_checker.h"
+
+// check_all runs all of the address checking functions to ensure that
+// the target load address is above all of the structures loaded by
+// GRUB. If this returns true, then the load address is safe and will
+// not clobber any of GRUB's or the module loader's structures.
+bool check_all(uint64_t load_addr) {
+  return false;
+}

--- a/module_loader/addr_checker.c
+++ b/module_loader/addr_checker.c
@@ -49,6 +49,9 @@ uint64_t check_mod(const Mod *mod) {
 uint64_t check_mods(const MIS *mis) {
   const Mod *mods = get_mods(mis);
   uint64_t max_addr = 0;
+  // we intentionally check all but the first module. Since we are
+  // relocating things using a safe memmove, it doesn't matter if the
+  // ELF itself overlaps the load address.
   for (size_t i = 1; i < mis->mods_count; ++i) {
     uint64_t mod_max = check_mod(&mods[i]);
     if (mod_max > max_addr) {

--- a/module_loader/addr_checker.h
+++ b/module_loader/addr_checker.h
@@ -6,6 +6,7 @@
 #include "stdint.h"
 #include "multiboot.h"
 
+uint64_t get_MIS_max_addr(const MIS *mis);
 bool check_all(const uint64_t load_addr, const MIS *mis);
 
 #endif

--- a/module_loader/addr_checker.h
+++ b/module_loader/addr_checker.h
@@ -4,7 +4,8 @@
 #include "stdbool.h"
 #include "stddef.h"
 #include "stdint.h"
+#include "multiboot.h"
 
-bool check_all(uint64_t load_addr);
+bool check_all(const uint64_t load_addr, const MIS *mis);
 
 #endif

--- a/module_loader/addr_checker.h
+++ b/module_loader/addr_checker.h
@@ -1,0 +1,10 @@
+#ifndef ADDR_CHECKER_H
+#define ADDR_CHECKER_H 1
+
+#include "stdbool.h"
+#include "stddef.h"
+#include "stdint.h"
+
+bool check_all(uint64_t load_addr);
+
+#endif

--- a/module_loader/elf.c
+++ b/module_loader/elf.c
@@ -77,3 +77,33 @@ Elf64_Addr get_elf64_entrypoint(const char *const elf) {
   const Elf64_Ehdr * const header = (const Elf64_Ehdr * const)elf;
   return header->e_entry;
 }
+
+Elf32_Addr get_elf32_lowest_addr(const char *const elf) {
+  const Elf32_Ehdr * const header = (const Elf32_Ehdr * const)elf;
+  const uint64_t p = (uint64_t)elf + (uint64_t)header->e_phoff;
+  const Elf32_Phdr * const pheader = (const Elf32_Phdr * const)p;
+  Elf32_Addr lowest_addr = 0xffffffff;
+
+  for (size_t i = 0; i < header->e_phnum; ++i) {
+    Elf32_Addr virt_addr = pheader[i].p_vaddr;
+    if (virt_addr < lowest_addr) {
+      lowest_addr = virt_addr;
+    }
+  }
+  return lowest_addr;
+}
+
+Elf64_Addr get_elf64_lowest_addr(const char *const elf) {
+  const Elf64_Ehdr * const header = (const Elf64_Ehdr * const)elf;
+  const uint64_t p = (uint64_t)elf + (uint64_t)header->e_phoff;
+  const Elf64_Phdr * const pheader = (const Elf64_Phdr * const)p;
+  Elf64_Addr lowest_addr = 0xffffffffffffffff;
+
+  for (size_t i = 0; i < header->e_phnum; ++i) {
+    Elf64_Addr virt_addr = pheader[i].p_vaddr;
+    if (virt_addr < lowest_addr) {
+      lowest_addr = virt_addr;
+    }
+  }
+  return lowest_addr;
+}

--- a/module_loader/elf.h
+++ b/module_loader/elf.h
@@ -102,4 +102,8 @@ void elf64_build_program_image(const char *const elf);
 Elf32_Addr get_elf32_entrypoint(const char *const elf);
 Elf64_Addr get_elf64_entrypoint(const char *const elf);
 
+// helpers
+Elf32_Addr get_elf32_lowest_addr(const char *const elf);
+Elf64_Addr get_elf64_lowest_addr(const char *const elf);
+
 #endif

--- a/module_loader/module_loader.c
+++ b/module_loader/module_loader.c
@@ -9,6 +9,7 @@
 #include "multiboot.h"
 #include "tty.h"
 #include "elf.h"
+#include "addr_checker.h"
 
 const MIS *mis;
 typedef union {
@@ -62,6 +63,21 @@ void module_loader_main() {
     return;
   }
   ++yline;
+
+  // determine the lowest virtual address of the ELF
+  uint64_t lowest_addr;
+  if (get_ELF_class(mod) == EI_CLASS_32BIT) {
+    lowest_addr = (uint64_t)get_elf32_lowest_addr(mod);
+  } else {
+    lowest_addr = get_elf64_lowest_addr(mod);
+  }
+
+  // check that the ELF can be safely loaded to that address
+  if (!check_all(lowest_addr)) {
+    terminal_color.fg = 4;
+    print_string("[E] ELF cannot be moved safely!", 0, yline);
+    return;
+  }
 
   // load the module
   if (get_ELF_class(mod) == EI_CLASS_32BIT) {

--- a/module_loader/module_loader.c
+++ b/module_loader/module_loader.c
@@ -73,7 +73,7 @@ void module_loader_main() {
   }
 
   // check that the ELF can be safely loaded to that address
-  if (!check_all(lowest_addr)) {
+  if (!check_all(lowest_addr, mis)) {
     terminal_color.fg = 4;
     print_string("[E] ELF cannot be moved safely!", 0, yline);
     return;


### PR DESCRIPTION
Since we are booting the OS somewhat indirectly (bootloader loads a protected mode program + the actual long mode kernel as a module + other structs), we can't rely on GRUB to put the kernel in the right place, and we will need to relocate it ourself. However, the kernel will likely still rely on some of the data loaded by GRUB (especially if we later decide to load other modules via GRUB). This adds some simple memory checks to ensure the kernel is not overwriting any structures created by GRUB.

This memory check is done by determining the highest address used by the GRUB structures (except for the kernel) and checking whether it is below the load address of the kernel ELF. This code can be reused later when ELF relocation is done using paging; this will let us find the first unused page frame to allocate the extra pages needed.