### PR TITLE
Directly map kernel into very high memory using paging

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -15,7 +15,7 @@ $(KERNEL_DIR)/mmap.o
 
 KERNEL_INCLUDES=$(wildcard $(KERNEL_DIR)/include/**/*.h) $(wildcard $(KERNEL_DIR)/include/*.h)
 
-KERNEL_CFLAGS?=-isystem=/usr/include
+KERNEL_CFLAGS?=-isystem=/usr/include -mcmodel=large
 
 $(KERNEL_DIR)/%.o: $(KERNEL_DIR)/%.c
 	$(CC) -MD -c '$<' -o '$@' -ffreestanding $(CFLAGS) $(KERNEL_CFLAGS)

--- a/kernel/arch/x86_64/entry.c
+++ b/kernel/arch/x86_64/entry.c
@@ -3,22 +3,6 @@
 extern const MIS *mis;
 extern void kernel_main();
 
-volatile static char stack[16*1024] __attribute__((section(".bss"))); // 16kB stack
-
-__attribute__((naked)) void _entry() {
-  __asm__ __volatile__ (
-    // set up the stack
-    "lea stack+16*1024, %rsp\r\n"
-    // forward EAX and EBX according to sysv convention
-    // arg1 passed as rdi
-    // arg2 passed as rsi
-    "xor %rdi, %rdi\r\n"
-    "mov %eax, %edi\r\n"
-    "xor %rsi, %rsi\r\n"
-    "mov %ebx, %esi\r\n"
-    "jmp _entry_c\r\n"
-                        );
-}
 __attribute__((noreturn,sysv_abi)) void _entry_c(uint32_t rax, MIS *rbx) {
   // if we were booted by a multiboot, we can save the pointer to the
   // MIS

--- a/kernel/arch/x86_64/entry_asm.nasm
+++ b/kernel/arch/x86_64/entry_asm.nasm
@@ -1,0 +1,18 @@
+        BITS 64
+
+        extern _entry_c
+        extern stack_top
+
+global _entry
+_entry:
+        ;; backup rax to rcx
+        mov rcx, rax
+        ;; set up the stack via rax
+        mov rax, stack_top
+        mov rsp, rax
+        ;; forward EAX and EBX according to sysv convention
+        xor rdi, rdi
+        mov edi, ecx
+        xor rsi, rsi
+        mov esi, ebx
+        jmp _entry_c

--- a/kernel/arch/x86_64/entry_asm.nasm
+++ b/kernel/arch/x86_64/entry_asm.nasm
@@ -8,6 +8,8 @@ _entry:
         ;; backup rax to rcx
         mov rcx, rax
         ;; set up the stack via rax
+        ;; we do it this way to avoid truncation of stack_top to a
+        ;; 32-bit symbol, since the stack is in very high memory now
         mov rax, stack_top
         mov rsp, rax
         ;; forward EAX and EBX according to sysv convention

--- a/kernel/arch/x86_64/linker.ld
+++ b/kernel/arch/x86_64/linker.ld
@@ -21,7 +21,7 @@ SECTIONS
 	{
 		*(.rodata)
                 *(.eh_frame)
-                *(.rodata.*)
+                *(.rodata*)
                 /* Pad out the section to the next page boundary */
                 FILL(0x00);
                 . = ALIGN(4K) - 1;

--- a/kernel/arch/x86_64/linker.ld
+++ b/kernel/arch/x86_64/linker.ld
@@ -8,7 +8,7 @@ ENTRY(_entry)
    kernel image. */
 SECTIONS
 {
-        . = 32M;
+        . = 0xfffffe8000200000;
         __kernel_start = .;
 
 	.text BLOCK(4K) : ALIGN(4K)
@@ -41,6 +41,15 @@ SECTIONS
 	/* Read-write data (uninitialized) and stack */
 	.bss BLOCK(4K) : ALIGN(4K)
 	{
+                /* Create stack in .bss directly.
+                   This allows us to access the stack directly from
+                   ASM, which we have to use to avoid symbol
+                   relocation errors.*/
+                . = ALIGN(16);
+                stack = .;
+                . += 16K;
+                stack_top = .;
+
 		*(COMMON)
 		*(.bss)
                 FILL(0x00);

--- a/kernel/arch/x86_64/linker.ld
+++ b/kernel/arch/x86_64/linker.ld
@@ -24,18 +24,12 @@ SECTIONS
 	.rodata BLOCK(4K) : ALIGN(4K)
 	{
 		*(.rodata)
+                *(.eh_frame)
+                *(.rodata.*)
                 FILL(0x00);
                 . = ALIGN(4K) - 1;
                 BYTE(0x00);
 	}
-
-        .eh_frame BLOCK(8) : ALIGN(8)
-        {
-                *(.eh_frame)
-                FILL(0x00);
-                . = ALIGN(4K) - 1;
-                BYTE(0x00);
-        }
 
 	/* Read-write data (initialized) */
 	.data BLOCK(4K) : ALIGN(4K)

--- a/kernel/arch/x86_64/linker.ld
+++ b/kernel/arch/x86_64/linker.ld
@@ -8,27 +8,43 @@ ENTRY(_entry)
    kernel image. */
 SECTIONS
 {
-	/* The module loader is loaded at a 2M offset. However, x86_64
-	generally requires 2MB aligment, so to make sure there is no
-	overlap between the module loader and the kernel, we ensure
-	that the kernel is loaded to an offset of 4M */
-        . = 4M;
+        . = 2M;
+        __kernel_start = .;
 
 	.text BLOCK(4K) : ALIGN(4K)
 	{
 		*(.text)
+                /* Pad out the section to the next page boundary */
+                FILL(0x00);
+                . = ALIGN(4K) - 1;
+                BYTE(0x00);
 	}
 
 	/* Read-only data. */
 	.rodata BLOCK(4K) : ALIGN(4K)
 	{
 		*(.rodata)
+                FILL(0x00);
+                . = ALIGN(4K) - 1;
+                BYTE(0x00);
 	}
+
+        .eh_frame BLOCK(8) : ALIGN(8)
+        {
+                *(.eh_frame)
+                FILL(0x00);
+                . = ALIGN(4K) - 1;
+                BYTE(0x00);
+        }
 
 	/* Read-write data (initialized) */
 	.data BLOCK(4K) : ALIGN(4K)
 	{
 		*(.data)
+                /* Pad out the section to the next page boundary */
+                FILL(0x00);
+                . = ALIGN(4K) - 1;
+                BYTE(0x00);
 	}
 
 	/* Read-write data (uninitialized) and stack */
@@ -36,7 +52,11 @@ SECTIONS
 	{
 		*(COMMON)
 		*(.bss)
+                FILL(0x00);
+                . = ALIGN(4K);
 	}
+
+        __kernel_end = .;
 
 	/* The compiler may produce other sections, by default it will put them in
 	   a segment with the same name. Simply add stuff here as needed. */

--- a/kernel/arch/x86_64/linker.ld
+++ b/kernel/arch/x86_64/linker.ld
@@ -8,7 +8,7 @@ ENTRY(_entry)
    kernel image. */
 SECTIONS
 {
-        . = 4M;
+        . = 32M;
         __kernel_start = .;
 
 	.text BLOCK(4K) : ALIGN(4K)

--- a/kernel/arch/x86_64/linker.ld
+++ b/kernel/arch/x86_64/linker.ld
@@ -8,7 +8,7 @@ ENTRY(_entry)
    kernel image. */
 SECTIONS
 {
-        . = 2M;
+        . = 4M;
         __kernel_start = .;
 
 	.text BLOCK(4K) : ALIGN(4K)

--- a/kernel/arch/x86_64/linker.ld
+++ b/kernel/arch/x86_64/linker.ld
@@ -14,10 +14,6 @@ SECTIONS
 	.text BLOCK(4K) : ALIGN(4K)
 	{
 		*(.text)
-                /* Pad out the section to the next page boundary */
-                FILL(0x00);
-                . = ALIGN(4K) - 1;
-                BYTE(0x00);
 	}
 
 	/* Read-only data. */
@@ -26,6 +22,7 @@ SECTIONS
 		*(.rodata)
                 *(.eh_frame)
                 *(.rodata.*)
+                /* Pad out the section to the next page boundary */
                 FILL(0x00);
                 . = ALIGN(4K) - 1;
                 BYTE(0x00);

--- a/kernel/arch/x86_64/linker.ld
+++ b/kernel/arch/x86_64/linker.ld
@@ -8,7 +8,7 @@ ENTRY(_entry)
    kernel image. */
 SECTIONS
 {
-        . = 0xfffffe8000200000;
+        . = 0xfffffe8000200000; /* PML4T[509] + 2MB */
         __kernel_start = .;
 
 	.text BLOCK(4K) : ALIGN(4K)

--- a/kernel/arch/x86_64/make.config
+++ b/kernel/arch/x86_64/make.config
@@ -3,10 +3,14 @@ grubiso/boot/jOShload.elf
 
 KERNEL_ARCH_OBJS=\
 $(KERNEL_ARCH_DIR)/entry.o \
+$(KERNEL_ARCH_DIR)/entry_asm.o \
 $(KERNEL_ARCH_DIR)/ioports.o
 
 $(KERNEL_ARCH_DIR)/%.o: $(KERNEL_ARCH_DIR)/%.c
 	$(CC) -MD -c '$<' -o '$@' -ffreestanding $(CFLAGS) $(KERNEL_CFLAGS)
+
+$(KERNEL_ARCH_DIR)/%.o: $(KERNEL_ARCH_DIR)/%.nasm
+	nasm -MD '$*.d' -f elf64 -o '$@' '$<'
 
 grubiso/boot/jOShload.elf: $(KERNEL_ARCH_DIR)/module_loader/loader.elf
 	mkdir -p grubiso/boot/

--- a/kernel/arch/x86_64/module_loader/Makefile
+++ b/kernel/arch/x86_64/module_loader/Makefile
@@ -10,7 +10,8 @@ putchar.o \
 puts.o \
 errno.o \
 strto.o \
-isspace.o
+isspace.o \
+bump_alloc.o
 
 loader.elf: module_loader.ld $(OBJS)
 	$(CC) -m32 -Wl,-m,elf_i386 -T '$<' -o '$@' -ffreestanding -nostdlib $(CFLAGS) $(filter-out $<,$^)

--- a/kernel/arch/x86_64/module_loader/Makefile
+++ b/kernel/arch/x86_64/module_loader/Makefile
@@ -2,6 +2,7 @@ OBJS=\
 bootstrap.o \
 module_loader.o \
 elf.o \
+elf_paged.o \
 addr_checker.o \
 long_load.o \
 tty.o \

--- a/kernel/arch/x86_64/module_loader/addr_checker.c
+++ b/kernel/arch/x86_64/module_loader/addr_checker.c
@@ -58,6 +58,14 @@ uint64_t check_mods(const MIS *mis) {
   return max_addr;
 }
 
+uint64_t check_mmap(const MIS *mis) {
+  const char *mmap = (const char*)get_mmap(mis);
+  for (size_t i = 0; i < mis->mmap_length; ++i) {
+    mmap += (uint32_t)(*mmap);
+  }
+  return (uint64_t)((uintptr_t)mmap);
+}
+
 // get_MIS_max_addr runs all of the functions for determining the max
 // addresses and returns the greatest of them.
 uint64_t get_MIS_max_addr(const MIS *mis) {
@@ -73,6 +81,10 @@ uint64_t get_MIS_max_addr(const MIS *mis) {
   const uint64_t cmdline = check_cmdline(mis);
   if (cmdline > max_addr) {
     max_addr = cmdline;
+  }
+  const uint64_t mmap = check_mmap(mis);
+  if (mmap > max_addr) {
+    max_addr = mmap;
   }
   return max_addr;
 }

--- a/kernel/arch/x86_64/module_loader/addr_checker.c
+++ b/kernel/arch/x86_64/module_loader/addr_checker.c
@@ -49,10 +49,7 @@ uint64_t check_mod(const Mod *mod) {
 uint64_t check_mods(const MIS *mis) {
   const Mod *mods = get_mods(mis);
   uint64_t max_addr = 0;
-  // we intentionally check all but the first module. Since we are
-  // relocating things using a safe memmove, it doesn't matter if the
-  // ELF itself overlaps the load address.
-  for (size_t i = 1; i < mis->mods_count; ++i) {
+  for (size_t i = 0; i < mis->mods_count; ++i) {
     uint64_t mod_max = check_mod(&mods[i]);
     if (mod_max > max_addr) {
       max_addr = mod_max;

--- a/kernel/arch/x86_64/module_loader/bump_alloc.c
+++ b/kernel/arch/x86_64/module_loader/bump_alloc.c
@@ -1,0 +1,28 @@
+#include <stdbool.h>
+#include "bump_alloc.h"
+
+typedef struct {
+  size_t addr;
+  bool init;
+} BumpAllocator;
+
+static BumpAllocator alloc = {0, false};
+
+void bump_init(const size_t addr) {
+  alloc.addr = addr;
+  alloc.init = true;
+}
+
+void bump_align(const size_t boundary) {
+  if (!alloc.init) return;
+  const size_t rem = alloc.addr % boundary;
+  if (rem == 0) return;
+  alloc.addr += boundary - rem;
+}
+
+void *bump_malloc(const size_t size) {
+  if (!alloc.init) return NULL;
+  void* p = (void*)alloc.addr;
+  alloc.addr += size;
+  return p;
+}

--- a/kernel/arch/x86_64/module_loader/bump_alloc.h
+++ b/kernel/arch/x86_64/module_loader/bump_alloc.h
@@ -1,0 +1,10 @@
+#ifndef __BUMP_ALLOC_H
+#define __BUMP_ALLOC_H
+
+#include <stddef.h>
+
+void bump_init(const size_t addr);
+void* bump_malloc(const size_t size);
+void bump_align(const size_t boundary);
+
+#endif

--- a/kernel/arch/x86_64/module_loader/elf_paged.c
+++ b/kernel/arch/x86_64/module_loader/elf_paged.c
@@ -1,0 +1,106 @@
+#include "elf_paged.h"
+#include "bump_alloc.h"
+#include <stdio.h>
+
+#define ERR_NOT_PAGE_ALIGNED -1
+#define ERR_FSIZE_NOT_PAGE -2
+
+void virtual_to_page_table_indices(uint64_t addr, size_t *pml4t_i,
+                                   size_t *pdpt_i, size_t *pd_i,
+                                   size_t *pt_i) {
+  if (pml4t_i == NULL || pdpt_i == NULL || pd_i == NULL || pt_i == NULL) return;
+
+  addr >>= 12;
+  *pt_i = addr & 511;
+  addr >>= 9;
+  *pd_i = addr & 511;
+  addr >>= 9;
+  *pdpt_i = addr & 511;
+  addr >>= 9;
+  *pml4t_i = addr & 511;
+}
+
+uint64_t *bump_malloc_pt() {
+  bump_align(0x1000);
+  uint64_t *addr = bump_malloc(sizeof(uint64_t) * 512);
+  /* printf("Page table created at 0x%08zx\n", (size_t)addr); */
+  return addr;
+}
+
+volatile uint64_t *fetch_page_table(volatile uint64_t *table, const size_t i) {
+  return (volatile uint64_t*)(table[i] & (UINT64_MAX - 0xfff));
+}
+
+static void zero_page_table(volatile uint64_t *table) {
+  for (size_t i = 0; i < 512; ++i) {
+    table[i] = 0;
+  }
+}
+
+int elf64_map_program_image(const char *const elf, volatile uint64_t *const pml4t) {
+  // Assumes all page tables were zeroed at allocation, and all
+  // allocated page tables have been added to the page table tree.
+  // This way, a non-zero entry in any page table -> a page table
+  // which has already been allocated. If we need to use an
+  // unallocated page table, we use the bump allocator to create it.
+  //
+  // Returns:
+  //    0 if program mapped successfully
+  //   -1 if a program segment was encountered with an offset which is
+  //      not page-aligned
+  //   -2 if a program segment was encountered with a fsize which is
+  //      not a multiple of the page size
+
+  const Elf64_Ehdr * const header = (const Elf64_Ehdr * const)elf;
+  const uint64_t p = (uint64_t)(uintptr_t)elf + (uint64_t)(uintptr_t)header->e_phoff;
+  const Elf64_Phdr * const pheader = (const Elf64_Phdr * const)(uintptr_t)p;
+
+  for (size_t i = 0; i < header->e_phnum; ++i) {
+    const void *const segment_start = (const void *const)(pheader[i].p_offset + elf);
+    if ((size_t)segment_start % 0x1000 != 0) return ERR_NOT_PAGE_ALIGNED;
+    const uint64_t virt_addr = pheader[i].p_vaddr;
+    if ((uint64_t)(uintptr_t)virt_addr % 0x1000 != 0) return ERR_NOT_PAGE_ALIGNED;
+    const size_t fsize = (size_t)pheader[i].p_filesz;
+    if (fsize % 0x1000 != 0) return ERR_FSIZE_NOT_PAGE;
+    const size_t msize = (size_t)pheader[i].p_memsz;
+
+    // map the contents of the file into memory
+    for (uint64_t j = 0; j < msize; j += 0x1000) {
+      // get the page table indices corresponding to the virtual address
+      size_t i0, i1, i2, i3;
+      virtual_to_page_table_indices(virt_addr+j, &i0, &i1, &i2, &i3);
+
+      // ensure all the tables exist
+      volatile uint64_t *pdpt = fetch_page_table(pml4t, i0);
+      if (pdpt == NULL) {
+        pml4t[i0] = (volatile uint64_t)bump_malloc_pt() | 3;
+        pdpt = fetch_page_table(pml4t, i0);
+        zero_page_table(pdpt);
+      }
+      volatile uint64_t *pd = fetch_page_table(pdpt, i1);
+      if (pd == NULL) {
+        pdpt[i1] = (volatile uint64_t)bump_malloc_pt() | 3;
+        pd = fetch_page_table(pdpt, i1);
+        zero_page_table(pd);
+      }
+      volatile uint64_t *pt = fetch_page_table(pd, i2);
+      if (pt == NULL) {
+        pd[i2] = (volatile uint64_t)bump_malloc_pt() | 3;
+        pt = fetch_page_table(pd, i2);
+        zero_page_table(pt);
+      }
+
+      if (j < fsize) { // still inside the real file
+        // point the table to the physical address of the real ELF
+        // content
+        pt[i3] = (volatile uint64_t)(segment_start + j) | 3;
+      } else { // nobits data
+        // allocate an empty page to store the data and point the
+        // table to it
+        pt[i3] = (volatile uint64_t)(bump_malloc(0x1000)) | 3;
+      }
+    }
+  }
+
+  return 0;
+}

--- a/kernel/arch/x86_64/module_loader/elf_paged.c
+++ b/kernel/arch/x86_64/module_loader/elf_paged.c
@@ -46,7 +46,7 @@ int elf64_map_program_image(const char *const elf, uint64_t *const pml4t) {
     const size_t msize = (size_t)pheader[i].p_memsz;
     if (msize % PAGE_ALIGNMENT != 0) return ERR_MSIZE_NOT_PAGE;
 
-    // map the contents of the file into memory
+    // map the contents of the file into memory one page at a time
     for (uint64_t j = 0; j < msize; j += PAGE_SIZE) {
       // get the page table indices corresponding to the virtual address
       size_t i0, i1, i2, i3;

--- a/kernel/arch/x86_64/module_loader/elf_paged.c
+++ b/kernel/arch/x86_64/module_loader/elf_paged.c
@@ -7,6 +7,7 @@
 #define ERR_VIR_NOT_PAGE_ALIGNED -2
 #define ERR_FSIZE_NOT_PAGE -3
 #define ERR_MSIZE_NOT_PAGE -4
+#define ERR_OTHER -255
 
 uint64_t *bump_malloc_pt() {
   bump_align(PAGE_ALIGNMENT);
@@ -49,7 +50,7 @@ int elf64_map_program_image(const char *const elf, uint64_t *const pml4t) {
     for (uint64_t j = 0; j < msize; j += PAGE_SIZE) {
       // get the page table indices corresponding to the virtual address
       size_t i0, i1, i2, i3;
-      virtual_to_page_table_indices(virt_addr+j, &i0, &i1, &i2, &i3);
+      if (virtual_to_page_table_indices(virt_addr+j, &i0, &i1, &i2, &i3) != 0) return ERR_OTHER;
 
       // ensure all the tables exist
       uint64_t *pdpt = fetch_page_table(pml4t, i0);

--- a/kernel/arch/x86_64/module_loader/elf_paged.h
+++ b/kernel/arch/x86_64/module_loader/elf_paged.h
@@ -1,0 +1,9 @@
+#ifndef __ELF_PAGED_H
+#define __ELF_PAGED_H
+
+#include <stdint.h>
+#include "elf.h"
+
+int elf64_map_program_image(const char *const, volatile uint64_t *const);
+
+#endif

--- a/kernel/arch/x86_64/module_loader/module_loader.c
+++ b/kernel/arch/x86_64/module_loader/module_loader.c
@@ -53,23 +53,6 @@ void module_loader_main() {
     return;
   }
 
-  // determine the lowest virtual address of the ELF
-  uint64_t lowest_addr;
-  if (get_ELF_class(mod) == EI_CLASS_32BIT) {
-    lowest_addr = (uint64_t)get_elf32_lowest_addr(mod);
-  } else {
-    printf("[+] Getting lowest... ");
-    lowest_addr = get_elf64_lowest_addr(mod);
-    printf("Done!\n");
-  }
-
-  // check that the ELF can be safely loaded to that address
-  if (!check_all(lowest_addr, mis)) {
-    term_set_fg(4);
-    printf("[E] ELF cannot be moved safely!\n");
-    return;
-  }
-
   // load the module
   if (get_ELF_class(mod) == EI_CLASS_32BIT) {
     printf("[+] Loading ELF... ");

--- a/kernel/arch/x86_64/module_loader/module_loader.c
+++ b/kernel/arch/x86_64/module_loader/module_loader.c
@@ -58,7 +58,9 @@ void module_loader_main() {
   if (get_ELF_class(mod) == EI_CLASS_32BIT) {
     lowest_addr = (uint64_t)get_elf32_lowest_addr(mod);
   } else {
+    printf("[+] Getting lowest... ");
     lowest_addr = get_elf64_lowest_addr(mod);
+    printf("Done!\n");
   }
 
   // check that the ELF can be safely loaded to that address
@@ -70,8 +72,9 @@ void module_loader_main() {
 
   // load the module
   if (get_ELF_class(mod) == EI_CLASS_32BIT) {
+    printf("[+] Loading ELF... ");
     elf32_build_program_image(mod);
-    printf("[+] ELF Loaded!\n");
+    printf("Done!\n");
     printf("[+] Jumping to entrypoint...\n");
 
     // make the call using inline assembly
@@ -81,8 +84,9 @@ void module_loader_main() {
     entry.entry32 = get_elf32_entrypoint(mod);
     asm ("jmp *%0\r\n" : : "m"(entry.entry32), "a"(0x2BADB002), "b"(mis) :);
   } else {
+    printf("[+] Loading ELF... ");
     elf64_build_program_image(mod);
-    printf("[+] ELF Loaded!\n");
+    printf("Done!\n");
     printf("[+] Setting up identity pages...\n");
     setup_page_tables();
     printf("[+] Jumping to entrypoint...\n");

--- a/kernel/arch/x86_64/module_loader/module_loader.c
+++ b/kernel/arch/x86_64/module_loader/module_loader.c
@@ -62,8 +62,9 @@ void module_loader_main() {
     printf("[+] Loading ELF... ");
     elf64_build_program_image(mod);
     printf("Done!\n");
-    printf("[+] Setting up identity pages...\n");
+    printf("[+] Setting up identity pages... ");
     setup_page_tables();
+    printf("Done!\n");
     printf("[+] Jumping to entrypoint...\n");
 
     entry.entry64 = get_elf64_entrypoint(mod);

--- a/kernel/arch/x86_64/module_loader/module_loader.c
+++ b/kernel/arch/x86_64/module_loader/module_loader.c
@@ -93,8 +93,32 @@ void module_loader_main() {
     setup_page_tables();
     printf("Done!\n");
     printf("[+] Mapping ELF... ");
-    elf64_map_program_image(mod, page_level_4_tab);
-    printf("Done!\n");
+    int map_err = elf64_map_program_image(mod, page_level_4_tab);
+    if (map_err == 0) {
+      printf("Done!\n");
+    } else {
+      term_set_fg(4);
+      printf("Err!\n      ");
+      switch (map_err) {
+      case -1:
+        printf("Offset");
+        break;
+      case -2:
+        printf("Virtual address");
+        break;
+      case -3:
+        printf("fsize");
+        break;
+      case -4:
+        printf("msize");
+        break;
+      default:
+        printf("Unknown error!\n");
+        return;
+      }
+      printf(" not page aligned!\n");
+      return;
+    }
     printf("[+] Jumping to long loader...\n");
 
     entry.entry64 = get_elf64_entrypoint(mod);

--- a/kernel/arch/x86_64/module_loader/module_loader.c
+++ b/kernel/arch/x86_64/module_loader/module_loader.c
@@ -55,17 +55,9 @@ void module_loader_main() {
 
   // load the module
   if (get_ELF_class(mod) == EI_CLASS_32BIT) {
-    printf("[+] Loading ELF... ");
-    elf32_build_program_image(mod);
-    printf("Done!\n");
-    printf("[+] Jumping to entrypoint...\n");
-
-    // make the call using inline assembly
-    // this way, we can guarantee the calling convention that we
-    // expect. We can also restore the multiboot loader's inputs at
-    // the same time.
-    entry.entry32 = get_elf32_entrypoint(mod);
-    asm ("jmp *%0\r\n" : : "m"(entry.entry32), "a"(0x2BADB002), "b"(mis) :);
+    term_set_fg(4);
+    printf("[E] Module loader does not support 32-bit ELFs\n");
+    return;
   } else {
     printf("[+] Loading ELF... ");
     elf64_build_program_image(mod);

--- a/kernel/arch/x86_64/module_loader/module_loader.c
+++ b/kernel/arch/x86_64/module_loader/module_loader.c
@@ -53,6 +53,11 @@ void module_loader_main() {
     return;
   }
 
+  // figure out the highest address used by the MIS
+  const size_t mis_max_addr = (size_t)get_MIS_max_addr(mis);
+  const size_t first_free_page = ((mis_max_addr+1) & (SIZE_MAX - 0xfff)) + 0x1000;
+  printf("[+] First free page at: 0x%08zx\n", first_free_page);
+
   // load the module
   if (get_ELF_class(mod) == EI_CLASS_32BIT) {
     term_set_fg(4);

--- a/kernel/arch/x86_64/module_loader/module_loader.c
+++ b/kernel/arch/x86_64/module_loader/module_loader.c
@@ -14,7 +14,8 @@
 #include "bump_alloc.h"
 #include "paging.h"
 
-extern const size_t __loader_end;
+extern const char __loader_end;
+const void *loader_end = &__loader_end;
 
 #define PREV_LINE term_get_pos_y()-1
 
@@ -79,7 +80,7 @@ void module_loader_main() {
 
   // find the first free address and set up the bump allocator
   const size_t mis_max_addr = (size_t)get_MIS_max_addr(mis);
-  const size_t highest_addr = mis_max_addr > __loader_end ? mis_max_addr : __loader_end;
+  const size_t highest_addr = mis_max_addr > (size_t)loader_end ? mis_max_addr : (size_t)loader_end;
   bump_init(highest_addr + 1);
   printf("[+] Bump allocator set up at 0x%08zx\n", (size_t)bump_malloc(0));
 

--- a/kernel/arch/x86_64/module_loader/module_loader.c
+++ b/kernel/arch/x86_64/module_loader/module_loader.c
@@ -32,6 +32,9 @@ volatile static uint64_t page_dir_ptr_tab[sz_PT] PT_ATTRS;
 // PML4T[0][0]: This is our initial identity map
 volatile static uint64_t page_dir[sz_PT] PT_ATTRS;
 
+// PML4T[509]: Kernel space
+volatile static uint64_t ks_pdpt[sz_PT] PT_ATTRS;
+
 const MIS *mis;
 typedef union {
   uint64_t entry64;
@@ -125,4 +128,7 @@ static void setup_page_tables() {
   page_dir[3] = (uint64_t)(0x600000) | 3 | 128;
   page_dir_ptr_tab[0] = (uint64_t)(uintptr_t)(page_dir) | 3;
   page_level_4_tab[0] = (uint64_t)(uintptr_t)(page_dir_ptr_tab) | 3;
+
+  // Add the kernel space entry
+  page_level_4_tab[sz_PT - 3] = (uint64_t)(uintptr_t)ks_pdpt | 3;
 }

--- a/kernel/arch/x86_64/module_loader/module_loader.c
+++ b/kernel/arch/x86_64/module_loader/module_loader.c
@@ -90,7 +90,7 @@ void module_loader_main() {
     printf("[E] Module loader does not support 32-bit ELFs\n");
     return;
   } else {
-    printf("[+] Setting up identity tables... ");
+    printf("[+] Setting up identity pages... ");
     setup_page_tables();
     printf("Done!\n");
     printf("[+] Mapping ELF... ");

--- a/kernel/arch/x86_64/module_loader/module_loader.c
+++ b/kernel/arch/x86_64/module_loader/module_loader.c
@@ -93,7 +93,6 @@ void module_loader_main() {
     elf64_map_program_image(mod, page_level_4_tab);
     printf("Done!\n");
     printf("[+] Jumping to long loader...\n");
-    return;
 
     entry.entry64 = get_elf64_entrypoint(mod);
     asm ("call switch_to_long" : : : );

--- a/kernel/arch/x86_64/module_loader/module_loader.ld
+++ b/kernel/arch/x86_64/module_loader/module_loader.ld
@@ -52,4 +52,6 @@ SECTIONS
 
 	/* The compiler may produce other sections, by default it will put them in
 	   a segment with the same name. Simply add stuff here as needed. */
+
+        __loader_end = .;
 }

--- a/kernel/arch/x86_64/module_loader/paging.c
+++ b/kernel/arch/x86_64/module_loader/paging.c
@@ -7,10 +7,10 @@ void zero_page_table(uint64_t *table) {
   }
 }
 
-void virtual_to_page_table_indices(uint64_t addr, size_t *pml4t_i,
+int virtual_to_page_table_indices(uint64_t addr, size_t *pml4t_i,
                                    size_t *pdpt_i, size_t *pd_i,
                                    size_t *pt_i) {
-  if (pml4t_i == NULL || pdpt_i == NULL || pd_i == NULL || pt_i == NULL) return;
+  if (pml4t_i == NULL || pdpt_i == NULL || pd_i == NULL || pt_i == NULL) return -1;
 
   addr >>= 12;
   *pt_i = addr & 511;
@@ -20,6 +20,8 @@ void virtual_to_page_table_indices(uint64_t addr, size_t *pml4t_i,
   *pdpt_i = addr & 511;
   addr >>= 9;
   *pml4t_i = addr & 511;
+
+  return 0;
 }
 
 uint64_t *fetch_page_table(uint64_t *table, const size_t i) {

--- a/kernel/arch/x86_64/module_loader/paging.h
+++ b/kernel/arch/x86_64/module_loader/paging.h
@@ -10,7 +10,7 @@
 
 void zero_page_table(uint64_t *table);
 
-void virtual_to_page_table_indices(uint64_t addr, size_t *pml4t_i,
+int virtual_to_page_table_indices(uint64_t addr, size_t *pml4t_i,
                                    size_t *pdpt_i, size_t *pd_i,
                                    size_t *pt_i);
 

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -19,7 +19,7 @@ _LIBC_OBJS=$(addsuffix .o, $(_LIBC_OBJ_NAMES))
 LIBK_OBJS=$(addprefix $(LIBC_DIR)/, $(_LIBK_OBJS))
 LIBC_OBJS=$(addprefix $(LIBC_DIR)/, $(_LIBC_OBJS))
 
-LIBK_CFLAGS?=-D__is_libk -isystem=/usr/include
+LIBK_CFLAGS?=-D__is_libk -isystem=/usr/include -mcmodel=large
 LIBC_CFLAGS?=-D__is_libc -isystem=/usr/include
 
 $(LIBC_DIR)/%.o: $(LIBC_DIR)/%.c


### PR DESCRIPTION
This PR modifies the module loader to map the program sections directly into their required virtual addresses using paging, rather than using an identity map and physically relocating the kernel sections. This has a few advantages:
  1. Since the kernel does not need to be moved at all, there is no concern about accidentally overwriting something we need.
  2. The kernel can be relocated to anywhere in virtual memory, not just addresses which physically exist.

This second point is particularly useful for when we want to execute userspace programs which use syscalls; the kernel can remain in very high memory at all times, so there is no need to constantly map and unmap the kernel.

In this case, the kernel is mapped into the address space under the third-to-last entry of the PML4T. This corresponds to the 512GB range of addresses from 0xFFFFFE8000000000 to 0xFFFFFF0000000000. 

Closes #39.

Remaining tasks:
  - [x] Clean up page management code into its own .c file. There's some WET code around ~, and this code will also be useful for the kernel~.
      - It would be nice to unify the code for the pages into the kernel eventually, but this would need to be part of a much wider effort. Since the details of paging are ultimately architecture-dependent, it would be unwise to integrate this code into the kernel as-is; rather, the architecture-independent parts of the kernel should have an architecture-independent interface to the underlying memory, backed by architecture-dependent memory management code. This will be a major undertaking in its own right that will need a lot more planning than really ought to go into this PR. For now, we will just keep the paging code local to the module loader, which is itself already x86-64 dependent. 
  - [x] Add error handling for mapping the ELF file. Error values are returned, but currently not used. If an error is returned, we can't boot the kernel and need to report the error.
  - [ ] ~Pass the current address of the bump allocator to the kernel at boot. Previously, with everything statically-allocated, the MIS could be parsed by the kernel to find the first free sector. With dynamic allocation via the bump allocator, this is no longer possible.~ Will not be handled here; this will be handled as part of the loader struct — see #43.