### PR TITLE
Refactor the paging code into its own file

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -15,7 +15,7 @@ $(KERNEL_DIR)/mmap.o
 
 KERNEL_INCLUDES=$(wildcard $(KERNEL_DIR)/include/**/*.h) $(wildcard $(KERNEL_DIR)/include/*.h)
 
-KERNEL_CFLAGS?=-isystem=/usr/include -mcmodel=large
+KERNEL_CFLAGS?=-isystem=/usr/include -mcmodel=large -mno-sse -mno-sse2 -mno-mmx
 
 $(KERNEL_DIR)/%.o: $(KERNEL_DIR)/%.c
 	$(CC) -MD -c '$<' -o '$@' -ffreestanding $(CFLAGS) $(KERNEL_CFLAGS)

--- a/kernel/arch/x86_64/make.config
+++ b/kernel/arch/x86_64/make.config
@@ -18,7 +18,7 @@ grubiso/boot/jOShload.elf: $(KERNEL_ARCH_DIR)/module_loader/loader.elf
 
 FORCE: ;
 $(KERNEL_ARCH_DIR)/module_loader/loader.elf: FORCE
-	$(MAKE) -C $(@D) "$(notdir $@)" CC="$(abspath $(CC))" CXX="$(abspath $(CXX))" STRIP="$(abspath $(STRIP))" TARGET_ARCH="$(TARGET_ARCH)" CFLAGS="$(CFLAGS) -isystem=/usr/include"
+	$(MAKE) -C $(@D) "$(notdir $@)" CC="$(abspath $(CC))" CXX="$(abspath $(CXX))" STRIP="$(abspath $(STRIP))" TARGET_ARCH="$(TARGET_ARCH)" CFLAGS="$(CFLAGS) -isystem=/usr/include -mno-sse -mno-sse2 -mno-mmx"
 
 .PHONY: kernel_arch_clean
 kernel_arch_clean:

--- a/kernel/arch/x86_64/module_loader/Makefile
+++ b/kernel/arch/x86_64/module_loader/Makefile
@@ -12,7 +12,8 @@ puts.o \
 errno.o \
 strto.o \
 isspace.o \
-bump_alloc.o
+bump_alloc.o \
+paging.o
 
 loader.elf: module_loader.ld $(OBJS)
 	$(CC) -m32 -Wl,-m,elf_i386 -T '$<' -o '$@' -ffreestanding -nostdlib $(CFLAGS) $(filter-out $<,$^)

--- a/kernel/arch/x86_64/module_loader/elf_paged.c
+++ b/kernel/arch/x86_64/module_loader/elf_paged.c
@@ -1,5 +1,6 @@
 #include "elf_paged.h"
 #include "bump_alloc.h"
+#include "paging.h"
 #include <stdio.h>
 
 #define ERR_OFF_NOT_PAGE_ALIGNED -1
@@ -7,36 +8,10 @@
 #define ERR_FSIZE_NOT_PAGE -3
 #define ERR_MSIZE_NOT_PAGE -4
 
-void virtual_to_page_table_indices(uint64_t addr, size_t *pml4t_i,
-                                   size_t *pdpt_i, size_t *pd_i,
-                                   size_t *pt_i) {
-  if (pml4t_i == NULL || pdpt_i == NULL || pd_i == NULL || pt_i == NULL) return;
-
-  addr >>= 12;
-  *pt_i = addr & 511;
-  addr >>= 9;
-  *pd_i = addr & 511;
-  addr >>= 9;
-  *pdpt_i = addr & 511;
-  addr >>= 9;
-  *pml4t_i = addr & 511;
-}
-
 uint64_t *bump_malloc_pt() {
-  bump_align(0x1000);
-  uint64_t *addr = bump_malloc(sizeof(uint64_t) * 512);
-  /* printf("Page table created at 0x%08zx\n", (size_t)addr); */
+  bump_align(PAGE_ALIGNMENT);
+  uint64_t *addr = bump_malloc(PAGE_SIZE);
   return addr;
-}
-
-volatile uint64_t *fetch_page_table(volatile uint64_t *table, const size_t i) {
-  return (volatile uint64_t*)(table[i] & (UINT64_MAX - 0xfff));
-}
-
-static void zero_page_table(volatile uint64_t *table) {
-  for (size_t i = 0; i < 512; ++i) {
-    table[i] = 0;
-  }
 }
 
 int elf64_map_program_image(const char *const elf, volatile uint64_t *const pml4t) {
@@ -56,23 +31,22 @@ int elf64_map_program_image(const char *const elf, volatile uint64_t *const pml4
   //      not a multiple of the page size
   //   -4 if a program segment was encountered with a msize which is
   //      not a multiple of the page size
-
   const Elf64_Ehdr * const header = (const Elf64_Ehdr * const)elf;
   const uint64_t p = (uint64_t)(uintptr_t)elf + (uint64_t)(uintptr_t)header->e_phoff;
   const Elf64_Phdr * const pheader = (const Elf64_Phdr * const)(uintptr_t)p;
 
   for (size_t i = 0; i < header->e_phnum; ++i) {
     const void *const segment_start = (const void *const)(pheader[i].p_offset + elf);
-    if ((size_t)segment_start % 0x1000 != 0) return ERR_OFF_NOT_PAGE_ALIGNED;
+    if ((size_t)segment_start % PAGE_ALIGNMENT != 0) return ERR_OFF_NOT_PAGE_ALIGNED;
     const uint64_t virt_addr = pheader[i].p_vaddr;
-    if ((uint64_t)(uintptr_t)virt_addr % 0x1000 != 0) return ERR_VIR_NOT_PAGE_ALIGNED;
+    if ((uint64_t)(uintptr_t)virt_addr % PAGE_ALIGNMENT != 0) return ERR_VIR_NOT_PAGE_ALIGNED;
     const size_t fsize = (size_t)pheader[i].p_filesz;
-    if (fsize % 0x1000 != 0) return ERR_FSIZE_NOT_PAGE;
+    if (fsize % PAGE_ALIGNMENT != 0) return ERR_FSIZE_NOT_PAGE;
     const size_t msize = (size_t)pheader[i].p_memsz;
-    if (msize % 0x1000 != 0) return ERR_MSIZE_NOT_PAGE;
+    if (msize % PAGE_ALIGNMENT != 0) return ERR_MSIZE_NOT_PAGE;
 
     // map the contents of the file into memory
-    for (uint64_t j = 0; j < msize; j += 0x1000) {
+    for (uint64_t j = 0; j < msize; j += PAGE_SIZE) {
       // get the page table indices corresponding to the virtual address
       size_t i0, i1, i2, i3;
       virtual_to_page_table_indices(virt_addr+j, &i0, &i1, &i2, &i3);
@@ -104,7 +78,7 @@ int elf64_map_program_image(const char *const elf, volatile uint64_t *const pml4
       } else { // nobits data
         // allocate an empty page to store the data and point the
         // table to it
-        pt[i3] = (volatile uint64_t)(bump_malloc(0x1000)) | 3;
+        pt[i3] = (volatile uint64_t)(bump_malloc(PAGE_SIZE)) | 3;
       }
     }
   }

--- a/kernel/arch/x86_64/module_loader/elf_paged.c
+++ b/kernel/arch/x86_64/module_loader/elf_paged.c
@@ -14,7 +14,7 @@ uint64_t *bump_malloc_pt() {
   return addr;
 }
 
-int elf64_map_program_image(const char *const elf, volatile uint64_t *const pml4t) {
+int elf64_map_program_image(const char *const elf, uint64_t *const pml4t) {
   // Assumes all page tables were zeroed at allocation, and all
   // allocated page tables have been added to the page table tree.
   // This way, a non-zero entry in any page table -> a page table
@@ -52,21 +52,21 @@ int elf64_map_program_image(const char *const elf, volatile uint64_t *const pml4
       virtual_to_page_table_indices(virt_addr+j, &i0, &i1, &i2, &i3);
 
       // ensure all the tables exist
-      volatile uint64_t *pdpt = fetch_page_table(pml4t, i0);
+      uint64_t *pdpt = fetch_page_table(pml4t, i0);
       if (pdpt == NULL) {
-        pml4t[i0] = (volatile uint64_t)bump_malloc_pt() | 3;
+        pml4t[i0] = (uint64_t)bump_malloc_pt() | 3;
         pdpt = fetch_page_table(pml4t, i0);
         zero_page_table(pdpt);
       }
-      volatile uint64_t *pd = fetch_page_table(pdpt, i1);
+      uint64_t *pd = fetch_page_table(pdpt, i1);
       if (pd == NULL) {
-        pdpt[i1] = (volatile uint64_t)bump_malloc_pt() | 3;
+        pdpt[i1] = (uint64_t)bump_malloc_pt() | 3;
         pd = fetch_page_table(pdpt, i1);
         zero_page_table(pd);
       }
-      volatile uint64_t *pt = fetch_page_table(pd, i2);
+      uint64_t *pt = fetch_page_table(pd, i2);
       if (pt == NULL) {
-        pd[i2] = (volatile uint64_t)bump_malloc_pt() | 3;
+        pd[i2] = (uint64_t)bump_malloc_pt() | 3;
         pt = fetch_page_table(pd, i2);
         zero_page_table(pt);
       }
@@ -74,11 +74,11 @@ int elf64_map_program_image(const char *const elf, volatile uint64_t *const pml4
       if (j < fsize) { // still inside the real file
         // point the table to the physical address of the real ELF
         // content
-        pt[i3] = (volatile uint64_t)(segment_start + j) | 3;
+        pt[i3] = (uint64_t)(segment_start + j) | 3;
       } else { // nobits data
         // allocate an empty page to store the data and point the
         // table to it
-        pt[i3] = (volatile uint64_t)(bump_malloc(PAGE_SIZE)) | 3;
+        pt[i3] = (uint64_t)(bump_malloc(PAGE_SIZE)) | 3;
       }
     }
   }

--- a/kernel/arch/x86_64/module_loader/elf_paged.h
+++ b/kernel/arch/x86_64/module_loader/elf_paged.h
@@ -4,6 +4,6 @@
 #include <stdint.h>
 #include "elf.h"
 
-int elf64_map_program_image(const char *const, volatile uint64_t *const);
+int elf64_map_program_image(const char *const, uint64_t *const);
 
 #endif

--- a/kernel/arch/x86_64/module_loader/module_loader.c
+++ b/kernel/arch/x86_64/module_loader/module_loader.c
@@ -26,14 +26,14 @@ extern const size_t __loader_end;
 #define PT_ATTRS __attribute__((aligned(PAGE_ALIGNMENT))) __attribute__((section(".bss")))
 
 // PML4T
-volatile uint64_t page_level_4_tab[LEN_PAGE_TABLE] PT_ATTRS;
+uint64_t page_level_4_tab[LEN_PAGE_TABLE] PT_ATTRS;
 // PML4T[0]
-volatile static uint64_t page_dir_ptr_tab[LEN_PAGE_TABLE] PT_ATTRS;
+static uint64_t page_dir_ptr_tab[LEN_PAGE_TABLE] PT_ATTRS;
 // PML4T[0][0]: This is our initial identity map
-volatile static uint64_t page_dir[LEN_PAGE_TABLE] PT_ATTRS;
+static uint64_t page_dir[LEN_PAGE_TABLE] PT_ATTRS;
 
 // PML4T[509]: Kernel space
-volatile static uint64_t ks_pdpt[LEN_PAGE_TABLE] PT_ATTRS;
+static uint64_t ks_pdpt[LEN_PAGE_TABLE] PT_ATTRS;
 
 const MIS *mis;
 typedef union {

--- a/kernel/arch/x86_64/module_loader/paging.c
+++ b/kernel/arch/x86_64/module_loader/paging.c
@@ -1,0 +1,28 @@
+#include "paging.h"
+#include <stdio.h>
+
+void zero_page_table(volatile uint64_t *table) {
+  for (size_t i = 0; i < LEN_PAGE_TABLE; ++i) {
+    table[i] = 0;
+  }
+}
+
+void virtual_to_page_table_indices(uint64_t addr, size_t *pml4t_i,
+                                   size_t *pdpt_i, size_t *pd_i,
+                                   size_t *pt_i) {
+  if (pml4t_i == NULL || pdpt_i == NULL || pd_i == NULL || pt_i == NULL) return;
+
+  addr >>= 12;
+  *pt_i = addr & 511;
+  addr >>= 9;
+  *pd_i = addr & 511;
+  addr >>= 9;
+  *pdpt_i = addr & 511;
+  addr >>= 9;
+  *pml4t_i = addr & 511;
+}
+
+volatile uint64_t *fetch_page_table(volatile uint64_t *table, const size_t i) {
+  return (volatile uint64_t*)(table[i] & (UINT64_MAX - 0xfff));
+}
+

--- a/kernel/arch/x86_64/module_loader/paging.c
+++ b/kernel/arch/x86_64/module_loader/paging.c
@@ -1,7 +1,7 @@
 #include "paging.h"
 #include <stdio.h>
 
-void zero_page_table(volatile uint64_t *table) {
+void zero_page_table(uint64_t *table) {
   for (size_t i = 0; i < LEN_PAGE_TABLE; ++i) {
     table[i] = 0;
   }
@@ -22,7 +22,7 @@ void virtual_to_page_table_indices(uint64_t addr, size_t *pml4t_i,
   *pml4t_i = addr & 511;
 }
 
-volatile uint64_t *fetch_page_table(volatile uint64_t *table, const size_t i) {
-  return (volatile uint64_t*)(table[i] & (UINT64_MAX - 0xfff));
+uint64_t *fetch_page_table(uint64_t *table, const size_t i) {
+  return (uint64_t*)(table[i] & (UINT64_MAX - 0xfff));
 }
 

--- a/kernel/arch/x86_64/module_loader/paging.h
+++ b/kernel/arch/x86_64/module_loader/paging.h
@@ -8,12 +8,12 @@
 #define PAGE_SIZE (sizeof(uint64_t)*LEN_PAGE_TABLE)
 #define PAGE_ALIGNMENT 0x1000
 
-void zero_page_table(volatile uint64_t *table);
+void zero_page_table(uint64_t *table);
 
 void virtual_to_page_table_indices(uint64_t addr, size_t *pml4t_i,
                                    size_t *pdpt_i, size_t *pd_i,
                                    size_t *pt_i);
 
-volatile uint64_t *fetch_page_table(volatile uint64_t *table, const size_t i);
+uint64_t *fetch_page_table(uint64_t *table, const size_t i);
 
 #endif

--- a/kernel/arch/x86_64/module_loader/paging.h
+++ b/kernel/arch/x86_64/module_loader/paging.h
@@ -1,0 +1,19 @@
+#ifndef __PAGING_H
+#define __PAGING_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define LEN_PAGE_TABLE 512
+#define PAGE_SIZE (sizeof(uint64_t)*LEN_PAGE_TABLE)
+#define PAGE_ALIGNMENT 0x1000
+
+void zero_page_table(volatile uint64_t *table);
+
+void virtual_to_page_table_indices(uint64_t addr, size_t *pml4t_i,
+                                   size_t *pdpt_i, size_t *pd_i,
+                                   size_t *pt_i);
+
+volatile uint64_t *fetch_page_table(volatile uint64_t *table, const size_t i);
+
+#endif

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -19,7 +19,7 @@ _LIBC_OBJS=$(addsuffix .o, $(_LIBC_OBJ_NAMES))
 LIBK_OBJS=$(addprefix $(LIBC_DIR)/, $(_LIBK_OBJS))
 LIBC_OBJS=$(addprefix $(LIBC_DIR)/, $(_LIBC_OBJS))
 
-LIBK_CFLAGS?=-D__is_libk -isystem=/usr/include -mcmodel=large
+LIBK_CFLAGS?=-D__is_libk -isystem=/usr/include -mcmodel=large -mno-sse -mno-sse2 -mno-mmx
 LIBC_CFLAGS?=-D__is_libc -isystem=/usr/include
 
 $(LIBC_DIR)/%.o: $(LIBC_DIR)/%.c


### PR DESCRIPTION
Doing this has the weird side effect of causing the compiler to start using SIMD instructions in elf64_map_program_image. This doesn't work in this early environment because we haven't enabled the necessary CR0 and CR4 flags for SSE, and it wouldn't surprise me if there was additionally an alignment error, since it's raising #GP and not #UD. Nonetheless, the solution is to disable SSE and MMX at the compiler-level; I believe this is good practice anyway (Linux generally doesn't permit SSE/MMX in the kernel) except in rare circumstances because it is necessary to use the (expensive) FXSAVE and FXRSTOR instructions to preserve the SSE, FPU and MMX states on return to userspace.