### PR TITLE
Allow booting without a text-mode console

### DIFF
--- a/kernel/arch/x86_64/module_loader/multiboot_header.c
+++ b/kernel/arch/x86_64/module_loader/multiboot_header.c
@@ -89,6 +89,6 @@ const struct multiboot_header header = {
                       M2IS_TYPE_MEMMAP},
         },
     .flags = {TAG(struct multiboot_flags, MB2_TYPE_FLAGS, 0),
-              .console_flags = MULTIBOOT_FLAG_REQUIRE_CONSOLE | MULTIBOOT_FLAG_EGA,
+              .console_flags = MULTIBOOT_FLAG_EGA,
     },
 };


### PR DESCRIPTION
We now tell bootloader that an EGA console is supported, but not mandatory. GRUB will generally still provide a text console where it's available, but the kernel can boot using either a bitmap framebuffer or a text-mode framebuffer.

This is the last piece of the puzzle in making the kernel support UEFI booting; as such, this PR closes #64.