### PR TITLE
Unify the module_loader Makefile with the overall Makefile hierarchy

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,7 +1,7 @@
 KERNEL_DIR?=.
 KERNEL_ARCH_DIR=$(KERNEL_DIR)/arch/$(TARGET_ARCH)
 
-include $(KERNEL_ARCH_DIR)/make.config
+include $(KERNEL_ARCH_DIR)/Makefile
 
 KERNEL_PREFIX?=$(SYSROOT)/usr
 KERNEL_INCLUDEDIR?=$(KERNEL_PREFIX)/include

--- a/kernel/arch/x86_64/Makefile
+++ b/kernel/arch/x86_64/Makefile
@@ -14,8 +14,8 @@ $(KERNEL_ARCH_DIR)/control_registers.o \
 $(KERNEL_ARCH_DIR)/memory/recursive_pt.o \
 $(KERNEL_ARCH_DIR)/memory/paging.o
 
-LOADER_DIR=$(KERNEL_ARCH_DIR)/module_loader
-include $(LOADER_DIR)/Makefile
+ARCH_LOADER_DIR=$(KERNEL_ARCH_DIR)/module_loader
+include $(ARCH_LOADER_DIR)/Makefile
 
 $(KERNEL_ARCH_DIR)/%.o: $(KERNEL_ARCH_DIR)/%.c
 	$(CC) -MD -c '$<' -o '$@' -ffreestanding $(CFLAGS) $(KERNEL_CFLAGS)
@@ -23,7 +23,7 @@ $(KERNEL_ARCH_DIR)/%.o: $(KERNEL_ARCH_DIR)/%.c
 $(KERNEL_ARCH_DIR)/%.o: $(KERNEL_ARCH_DIR)/%.nasm
 	nasm -MD '$(KERNEL_ARCH_DIR)/$*.d' -f elf64 -o '$@' '$<'
 
-grubiso/boot/jOShload.elf: $(LOADER_DIR)/loader.elf
+grubiso/boot/jOShload.elf: $(ARCH_LOADER_DIR)/loader.elf
 	mkdir -p grubiso/boot/
 	cp '$(KERNEL_ARCH_DIR)/module_loader/loader.elf' grubiso/boot/jOShload.elf
 

--- a/kernel/arch/x86_64/Makefile
+++ b/kernel/arch/x86_64/Makefile
@@ -14,23 +14,21 @@ $(KERNEL_ARCH_DIR)/control_registers.o \
 $(KERNEL_ARCH_DIR)/memory/recursive_pt.o \
 $(KERNEL_ARCH_DIR)/memory/paging.o
 
+LOADER_DIR=$(KERNEL_ARCH_DIR)/module_loader
+include $(LOADER_DIR)/Makefile
+
 $(KERNEL_ARCH_DIR)/%.o: $(KERNEL_ARCH_DIR)/%.c
 	$(CC) -MD -c '$<' -o '$@' -ffreestanding $(CFLAGS) $(KERNEL_CFLAGS)
 
 $(KERNEL_ARCH_DIR)/%.o: $(KERNEL_ARCH_DIR)/%.nasm
 	nasm -MD '$(KERNEL_ARCH_DIR)/$*.d' -f elf64 -o '$@' '$<'
 
-grubiso/boot/jOShload.elf: $(KERNEL_ARCH_DIR)/module_loader/loader.elf
+grubiso/boot/jOShload.elf: $(LOADER_DIR)/loader.elf
 	mkdir -p grubiso/boot/
 	cp '$(KERNEL_ARCH_DIR)/module_loader/loader.elf' grubiso/boot/jOShload.elf
 
-FORCE: ;
-$(KERNEL_ARCH_DIR)/module_loader/loader.elf: FORCE
-	$(MAKE) -C $(@D) "$(notdir $@)" CC="$(abspath $(CC))" CXX="$(abspath $(CXX))" STRIP="$(abspath $(STRIP))" OBJCOPY="$(OBJCOPY)" TARGET_ARCH="$(TARGET_ARCH)" CFLAGS="$(CFLAGS) -isystem=/usr/include -msoft-float -mno-sse -mno-sse2 -mno-sse3 -mno-sse4 -mno-mmx"
-
 .PHONY: kernel_arch_clean
-kernel_arch_clean:
-	$(MAKE) -C '$(KERNEL_ARCH_DIR)/module_loader' clean
+kernel_arch_clean: arch_loader_clean
 	rm -f $(KERNEL_ARCH_OBJS)
 	rm -f $(KERNEL_ARCH_OBJS:.o=.d)
 

--- a/kernel/arch/x86_64/module_loader/Makefile
+++ b/kernel/arch/x86_64/module_loader/Makefile
@@ -1,7 +1,7 @@
-LOADER_DIR?=.
+ARCH_LOADER_DIR?=.
 KERNEL_DIR?=../../..
 LIBC_DIR?=../../../../libc
-_LOADER_OBJS=\
+_ARCH_LOADER_OBJS=\
 bootstrap.o \
 module_loader.o \
 multiboot_header.o \
@@ -29,61 +29,61 @@ null_console_driver.o \
 bootstrap_display.o \
 bootstrap_static_bump.o \
 kmap.o
-LOADER_OBJS=$(addprefix $(LOADER_DIR)/, $(_LOADER_OBJS))
+ARCH_LOADER_OBJS=$(addprefix $(ARCH_LOADER_DIR)/, $(_ARCH_LOADER_OBJS))
 
-LOADER_CFLAGS?=$(CFLAGS) -isystem=/usr/include -msoft-float -mno-sse -mno-sse2 -mno-sse3 -mno-sse4 -mno-mmx
+ARCH_LOADER_CFLAGS?=$(CFLAGS) -isystem=/usr/include -msoft-float -mno-sse -mno-sse2 -mno-sse3 -mno-sse4 -mno-mmx
 
-$(LOADER_DIR)/loader.elf: $(LOADER_DIR)/module_loader.ld $(LOADER_OBJS)
-	$(CC) -m32 -Wl,-m,elf_i386 -T '$<' -o '$@' -ffreestanding -nostdlib $(LOADER_CFLAGS) $(filter-out $<,$^) -lgcc
+$(ARCH_LOADER_DIR)/loader.elf: $(ARCH_LOADER_DIR)/module_loader.ld $(ARCH_LOADER_OBJS)
+	$(CC) -m32 -Wl,-m,elf_i386 -T '$<' -o '$@' -ffreestanding -nostdlib $(ARCH_LOADER_CFLAGS) $(filter-out $<,$^) -lgcc
 	$(STRIP) --strip-unneeded '$@'
 	grub-file --is-x86-multiboot2 '$@'
 
-$(LOADER_DIR)/tty.o: $(KERNEL_DIR)/tty.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(LOADER_CFLAGS)
+$(ARCH_LOADER_DIR)/tty.o: $(KERNEL_DIR)/tty.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(ARCH_LOADER_CFLAGS)
 
-$(LOADER_DIR)/bootstruct.o: $(KERNEL_DIR)/bootstruct.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(LOADER_CFLAGS)
+$(ARCH_LOADER_DIR)/bootstruct.o: $(KERNEL_DIR)/bootstruct.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(ARCH_LOADER_CFLAGS)
 
-$(LOADER_DIR)/%.o: $(LIBC_DIR)/stdio/%.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(LOADER_CFLAGS)
+$(ARCH_LOADER_DIR)/%.o: $(LIBC_DIR)/stdio/%.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(ARCH_LOADER_CFLAGS)
 
-$(LOADER_DIR)/%.o: $(LIBC_DIR)/stdlib/%.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(LOADER_CFLAGS)
+$(ARCH_LOADER_DIR)/%.o: $(LIBC_DIR)/stdlib/%.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(ARCH_LOADER_CFLAGS)
 
-$(LOADER_DIR)/%.o: $(LIBC_DIR)/ctype/%.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(LOADER_CFLAGS)
+$(ARCH_LOADER_DIR)/%.o: $(LIBC_DIR)/ctype/%.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(ARCH_LOADER_CFLAGS)
 
-$(LOADER_DIR)/%.o: $(LIBC_DIR)/string/%.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(LOADER_CFLAGS)
+$(ARCH_LOADER_DIR)/%.o: $(LIBC_DIR)/string/%.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(ARCH_LOADER_CFLAGS)
 
-$(LOADER_DIR)/errno.o: $(LIBC_DIR)/errno/errno.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(LOADER_CFLAGS)
+$(ARCH_LOADER_DIR)/errno.o: $(LIBC_DIR)/errno/errno.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(ARCH_LOADER_CFLAGS)
 
-$(LOADER_DIR)/ega_driver.o: $(KERNEL_DIR)/drivers/ega/ega.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(LOADER_CFLAGS)
+$(ARCH_LOADER_DIR)/ega_driver.o: $(KERNEL_DIR)/drivers/ega/ega.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(ARCH_LOADER_CFLAGS)
 
-$(LOADER_DIR)/bitmap_console_driver.o: $(KERNEL_DIR)/drivers/bitmap_console/bitmap_console.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(LOADER_CFLAGS)
+$(ARCH_LOADER_DIR)/bitmap_console_driver.o: $(KERNEL_DIR)/drivers/bitmap_console/bitmap_console.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(ARCH_LOADER_CFLAGS)
 
-$(LOADER_DIR)/bitmap_console_font.o: $(KERNEL_DIR)/drivers/bitmap_console/default_font.psf
+$(ARCH_LOADER_DIR)/bitmap_console_font.o: $(KERNEL_DIR)/drivers/bitmap_console/default_font.psf
 	cd '$(dir $(abspath $<))' && $(OBJCOPY) -O elf32-i386 -I binary '$(notdir $<)' '$(abspath $@)'
 
-$(LOADER_DIR)/null_console_driver.o: $(KERNEL_DIR)/drivers/null_console/null.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(LOADER_CFLAGS)
+$(ARCH_LOADER_DIR)/null_console_driver.o: $(KERNEL_DIR)/drivers/null_console/null.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(ARCH_LOADER_CFLAGS)
 
-$(LOADER_DIR)/bootstrap_%.o: $(KERNEL_DIR)/bootstrap/%.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(LOADER_CFLAGS)
+$(ARCH_LOADER_DIR)/bootstrap_%.o: $(KERNEL_DIR)/bootstrap/%.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(ARCH_LOADER_CFLAGS)
 
-$(LOADER_DIR)/%.o: $(LOADER_DIR)/%.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(LOADER_CFLAGS)
+$(ARCH_LOADER_DIR)/%.o: $(ARCH_LOADER_DIR)/%.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(ARCH_LOADER_CFLAGS)
 
-$(LOADER_DIR)/%.o: $(LOADER_DIR)/%.nasm
+$(ARCH_LOADER_DIR)/%.o: $(ARCH_LOADER_DIR)/%.nasm
 	nasm -MD '$*.d' -f elf32 -o '$@' '$<'
 
 .PHONY: arch_loader_clean
 arch_loader_clean:
-	rm -f $(LOADER_OBJS)
-	rm -f $(LOADER_OBJS:.o=.d)
+	rm -f $(ARCH_LOADER_OBJS)
+	rm -f $(ARCH_LOADER_OBJS:.o=.d)
 	rm -f ./loader.elf
 
--include $(LOADER_OBJS:.o=.d)
+-include $(ARCH_LOADER_OBJS:.o=.d)

--- a/kernel/arch/x86_64/module_loader/Makefile
+++ b/kernel/arch/x86_64/module_loader/Makefile
@@ -1,4 +1,7 @@
-OBJS=\
+LOADER_DIR?=.
+KERNEL_DIR?=../../..
+LIBC_DIR?=../../../../libc
+_LOADER_OBJS=\
 bootstrap.o \
 module_loader.o \
 multiboot_header.o \
@@ -26,62 +29,61 @@ null_console_driver.o \
 bootstrap_display.o \
 bootstrap_static_bump.o \
 kmap.o
+LOADER_OBJS=$(addprefix $(LOADER_DIR)/, $(_LOADER_OBJS))
 
-loader.elf: module_loader.ld $(OBJS)
-	$(CC) -m32 -Wl,-m,elf_i386 -T '$<' -o '$@' -ffreestanding -nostdlib $(CFLAGS) $(filter-out $<,$^) -lgcc
+LOADER_CFLAGS?=$(CFLAGS) -isystem=/usr/include -msoft-float -mno-sse -mno-sse2 -mno-sse3 -mno-sse4 -mno-mmx
+
+$(LOADER_DIR)/loader.elf: $(LOADER_DIR)/module_loader.ld $(LOADER_OBJS)
+	$(CC) -m32 -Wl,-m,elf_i386 -T '$<' -o '$@' -ffreestanding -nostdlib $(LOADER_CFLAGS) $(filter-out $<,$^) -lgcc
 	$(STRIP) --strip-unneeded '$@'
 	grub-file --is-x86-multiboot2 '$@'
 
-tty.o: ../../../tty.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(CFLAGS)
+$(LOADER_DIR)/tty.o: $(KERNEL_DIR)/tty.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(LOADER_CFLAGS)
 
-bootstruct.o: ../../../bootstruct.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(CFLAGS)
+$(LOADER_DIR)/bootstruct.o: $(KERNEL_DIR)/bootstruct.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(LOADER_CFLAGS)
 
-%.o: ../../../../libc/stdio/%.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(CFLAGS)
+$(LOADER_DIR)/%.o: $(LIBC_DIR)/stdio/%.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(LOADER_CFLAGS)
 
-%.o: ../../../../libc/stdlib/%.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(CFLAGS)
+$(LOADER_DIR)/%.o: $(LIBC_DIR)/stdlib/%.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(LOADER_CFLAGS)
 
-%.o: ../../../../libc/ctype/%.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(CFLAGS)
+$(LOADER_DIR)/%.o: $(LIBC_DIR)/ctype/%.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(LOADER_CFLAGS)
 
-%.o: ../../../../libc/string/%.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(CFLAGS)
+$(LOADER_DIR)/%.o: $(LIBC_DIR)/string/%.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(LOADER_CFLAGS)
 
-errno.o: ../../../../libc/errno/errno.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(CFLAGS)
+$(LOADER_DIR)/errno.o: $(LIBC_DIR)/errno/errno.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding -D__is_libk $(LOADER_CFLAGS)
 
-ega_driver.o: ../../../drivers/ega/ega.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(CFLAGS)
+$(LOADER_DIR)/ega_driver.o: $(KERNEL_DIR)/drivers/ega/ega.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(LOADER_CFLAGS)
 
-bitmap_console_driver.o: ../../../drivers/bitmap_console/bitmap_console.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(CFLAGS)
+$(LOADER_DIR)/bitmap_console_driver.o: $(KERNEL_DIR)/drivers/bitmap_console/bitmap_console.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(LOADER_CFLAGS)
 
-bitmap_console_font.o: ../../../drivers/bitmap_console/default_font.psf
+$(LOADER_DIR)/bitmap_console_font.o: $(KERNEL_DIR)/drivers/bitmap_console/default_font.psf
 	cd '$(dir $(abspath $<))' && $(OBJCOPY) -O elf32-i386 -I binary '$(notdir $<)' '$(abspath $@)'
 
-null_console_driver.o: ../../../drivers/null_console/null.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(CFLAGS)
+$(LOADER_DIR)/null_console_driver.o: $(KERNEL_DIR)/drivers/null_console/null.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(LOADER_CFLAGS)
 
-bootstrap_%.o: ../../../bootstrap/%.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(CFLAGS)
+$(LOADER_DIR)/bootstrap_%.o: $(KERNEL_DIR)/bootstrap/%.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(LOADER_CFLAGS)
 
-%.o: %.c
-	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(CFLAGS)
+$(LOADER_DIR)/%.o: $(LOADER_DIR)/%.c
+	$(CC) -MD -m32 -c '$<' -o '$@' -ffreestanding $(LOADER_CFLAGS)
 
-%.o: %.nasm
+$(LOADER_DIR)/%.o: $(LOADER_DIR)/%.nasm
 	nasm -MD '$*.d' -f elf32 -o '$@' '$<'
 
-FORCE: ;
-jBoot/%: FORCE
-	$(MAKE) -C $(@D) "$(notdir $@)" BOOT_FN=$(BOOT_FN) BOOT_EXT=$(BOOT_EXT)
-
-.PHONY: clean
-clean:
-	rm -f $(OBJS)
-	rm -f $(OBJS:.o=.d)
+.PHONY: arch_loader_clean
+arch_loader_clean:
+	rm -f $(LOADER_OBJS)
+	rm -f $(LOADER_OBJS:.o=.d)
 	rm -f ./loader.elf
 
--include $(OBJS:.o=.d)
+-include $(LOADER_OBJS:.o=.d)


### PR DESCRIPTION
Add module_loader to the Makefile hierarchy via `include`.

It inherits `KERNEL_DIR`, `KERNEL_ARCH_DIR` and `LIBC_DIR`, which allows more natural access to dependencies in these directories, but requires the parent to set `LOADER_DIR`. All objects must use the `LOADER_DIR` prefix (this is enforced with an `addprefix` rule). Any rules that previously depended on the `loader.elf` should just work automatically, and will no longer require the awkward `FORCE` workaround -- the recipes for the loader will be discovered automatically, and will support proper multithreaded compiling.