### PR TITLE
Unify kernel image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,6 @@ include $(LIBC_DIR)/Makefile
 jOSh.iso: grubiso/boot/jOSh.elf grubiso/boot/grub/grub.cfg $(KERNEL_ARCH_ISO_DEPENDS)
 	grub-mkrescue -o jOSh.iso grubiso
 
-grubiso/boot/jOSh.elf: kernel/kernel.elf
-	mkdir -p grubiso/boot/
-	cp kernel/kernel.elf grubiso/boot/jOSh.elf
-
 grubiso/boot/grub/grub.cfg: $(KERNEL_ARCH_DIR)/grub.cfg
 	mkdir -p grubiso/boot/grub/
 	cp $(KERNEL_ARCH_DIR)/grub.cfg grubiso/boot/grub/grub.cfg

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ all: jOSh.iso
 include $(KERNEL_DIR)/Makefile
 include $(LIBC_DIR)/Makefile
 
+# grubiso/boot/jOSh.elf recipe should be defined by the arch
 jOSh.iso: grubiso/boot/jOSh.elf grubiso/boot/grub/grub.cfg $(KERNEL_ARCH_ISO_DEPENDS)
 	grub-mkrescue -o jOSh.iso grubiso
 

--- a/kernel/arch/x86_64/Makefile
+++ b/kernel/arch/x86_64/Makefile
@@ -1,5 +1,4 @@
-KERNEL_ARCH_ISO_DEPENDS=\
-grubiso/boot/jOShload.elf
+KERNEL_ARCH_ISO_DEPENDS=
 
 KERNEL_ARCH_OBJS=\
 $(KERNEL_ARCH_DIR)/entry.o \
@@ -23,9 +22,9 @@ $(KERNEL_ARCH_DIR)/%.o: $(KERNEL_ARCH_DIR)/%.c
 $(KERNEL_ARCH_DIR)/%.o: $(KERNEL_ARCH_DIR)/%.nasm
 	nasm -MD '$(KERNEL_ARCH_DIR)/$*.d' -f elf64 -o '$@' '$<'
 
-grubiso/boot/jOShload.elf: $(ARCH_LOADER_DIR)/loader.elf
+grubiso/boot/jOSh.elf: $(ARCH_LOADER_DIR)/loader.elf
 	mkdir -p grubiso/boot/
-	cp '$(KERNEL_ARCH_DIR)/module_loader/loader.elf' grubiso/boot/jOShload.elf
+	cp '$<' '$@'
 
 .PHONY: kernel_arch_clean
 kernel_arch_clean: arch_loader_clean

--- a/kernel/arch/x86_64/grub.cfg
+++ b/kernel/arch/x86_64/grub.cfg
@@ -5,6 +5,5 @@ set timeout=0
 insmod all_video
 
 menuentry "jOSh" {
-	multiboot2 /boot/jOShload.elf
-	module2 /boot/jOSh.elf "KERNEL.ELF"
+	multiboot2 /boot/jOSh.elf
 }

--- a/kernel/arch/x86_64/module_loader/Makefile
+++ b/kernel/arch/x86_64/module_loader/Makefile
@@ -34,7 +34,7 @@ ARCH_LOADER_OBJS=$(addprefix $(ARCH_LOADER_DIR)/, $(_ARCH_LOADER_OBJS))
 
 ARCH_LOADER_OBJCOPY_SYM_NAME=_binary_$(shell printf '%s' '$(KERNEL_DIR)/kernel.elf' | sed 's/[^[:alnum:]]/_/g')
 
-ARCH_LOADER_CFLAGS?=$(CFLAGS) -isystem=/usr/include -msoft-float -mno-sse -mno-sse2 -mno-sse3 -mno-sse4 -mno-mmx -DOBJCOPY_SYM_NAME='$(ARCH_LOADER_OBJCOPY_SYM_NAME)'
+ARCH_LOADER_CFLAGS?=$(CFLAGS) -isystem=/usr/include -msoft-float -mno-sse -mno-sse2 -mno-sse3 -mno-sse4 -mno-mmx -DOBJCOPY_KERNEL_ELF_START='$(ARCH_LOADER_OBJCOPY_SYM_NAME)_start' -DOBJCOPY_KERNEL_ELF_SIZE='$(ARCH_LOADER_OBJCOPY_SYM_NAME)_size' -DOBJCOPY_KERNEL_ELF_END='$(ARCH_LOADER_OBJCOPY_SYM_NAME)_end'
 
 $(ARCH_LOADER_DIR)/loader.elf: $(ARCH_LOADER_DIR)/module_loader.ld $(ARCH_LOADER_OBJS)
 	$(CC) -m32 -Wl,-m,elf_i386 -T '$<' -o '$@' -ffreestanding -nostdlib $(ARCH_LOADER_CFLAGS) $(filter-out $<,$^) -lgcc

--- a/kernel/arch/x86_64/module_loader/Makefile
+++ b/kernel/arch/x86_64/module_loader/Makefile
@@ -38,7 +38,7 @@ ARCH_LOADER_CFLAGS?=$(CFLAGS) -isystem=/usr/include -msoft-float -mno-sse -mno-s
 
 $(ARCH_LOADER_DIR)/loader.elf: $(ARCH_LOADER_DIR)/module_loader.ld $(ARCH_LOADER_OBJS)
 	$(CC) -m32 -Wl,-m,elf_i386 -T '$<' -o '$@' -ffreestanding -nostdlib $(ARCH_LOADER_CFLAGS) $(filter-out $<,$^) -lgcc
-	$(STRIP) --strip-unneeded '$@'
+	$(STRIP) --strip-unneeded -K '$(ARCH_LOADER_OBJCOPY_SYM_NAME)_start' -K '$(ARCH_LOADER_OBJCOPY_SYM_NAME)_size' -K '$(ARCH_LOADER_OBJCOPY_SYM_NAME)_end' '$@'
 	grub-file --is-x86-multiboot2 '$@'
 
 $(ARCH_LOADER_DIR)/tty.o: $(KERNEL_DIR)/tty.c

--- a/kernel/arch/x86_64/module_loader/Makefile
+++ b/kernel/arch/x86_64/module_loader/Makefile
@@ -2,6 +2,7 @@ ARCH_LOADER_DIR?=.
 KERNEL_DIR?=../../..
 LIBC_DIR?=../../../../libc
 _ARCH_LOADER_OBJS=\
+kernel_elf.o \
 bootstrap.o \
 module_loader.o \
 multiboot_header.o \
@@ -31,7 +32,9 @@ bootstrap_static_bump.o \
 kmap.o
 ARCH_LOADER_OBJS=$(addprefix $(ARCH_LOADER_DIR)/, $(_ARCH_LOADER_OBJS))
 
-ARCH_LOADER_CFLAGS?=$(CFLAGS) -isystem=/usr/include -msoft-float -mno-sse -mno-sse2 -mno-sse3 -mno-sse4 -mno-mmx
+ARCH_LOADER_OBJCOPY_SYM_NAME=_binary_$(shell printf '%s' '$(KERNEL_DIR)/kernel.elf' | sed 's/[^[:alnum:]]/_/g')
+
+ARCH_LOADER_CFLAGS?=$(CFLAGS) -isystem=/usr/include -msoft-float -mno-sse -mno-sse2 -mno-sse3 -mno-sse4 -mno-mmx -DOBJCOPY_SYM_NAME='$(ARCH_LOADER_OBJCOPY_SYM_NAME)'
 
 $(ARCH_LOADER_DIR)/loader.elf: $(ARCH_LOADER_DIR)/module_loader.ld $(ARCH_LOADER_OBJS)
 	$(CC) -m32 -Wl,-m,elf_i386 -T '$<' -o '$@' -ffreestanding -nostdlib $(ARCH_LOADER_CFLAGS) $(filter-out $<,$^) -lgcc
@@ -79,6 +82,9 @@ $(ARCH_LOADER_DIR)/%.o: $(ARCH_LOADER_DIR)/%.c
 
 $(ARCH_LOADER_DIR)/%.o: $(ARCH_LOADER_DIR)/%.nasm
 	nasm -MD '$*.d' -f elf32 -o '$@' '$<'
+
+$(ARCH_LOADER_DIR)/kernel_elf.o: $(KERNEL_DIR)/kernel.elf
+	objcopy --input-target binary --output-target elf32-i386 --rename-section .data=.kernelelf,alloc,load,readonly,data,contents '$<' '$@'
 
 .PHONY: arch_loader_clean
 arch_loader_clean:

--- a/kernel/arch/x86_64/module_loader/module_loader.c
+++ b/kernel/arch/x86_64/module_loader/module_loader.c
@@ -88,10 +88,10 @@ void module_loader_main() {
   // verify that the module is an ELF file
   if (!is_ELF(kernel_elf_start)) {
     term_set_fg(4);
-    printf("      Unknown format\n");
+    printf("[!] Embedded ELF has unknown format!\n");
     return;
   }
-  printf("      Valid ELF!\n");
+  printf("[+] Embedded ELF found!\n");
 
   // print the ELF info
   printf("      ELF %s-bit %s\n",

--- a/kernel/arch/x86_64/module_loader/module_loader.c
+++ b/kernel/arch/x86_64/module_loader/module_loader.c
@@ -21,6 +21,11 @@
 extern const char __loader_end;
 const void *loader_end = &__loader_end;
 
+extern const char OBJCOPY_KERNEL_ELF_START;
+const char *kernel_elf_start = &(OBJCOPY_KERNEL_ELF_START);
+extern const char OBJCOPY_KERNEL_ELF_END;
+const char *kernel_elf_end = &(OBJCOPY_KERNEL_ELF_END);
+
 #define PREV_LINE term_get_pos_y()-1
 
 /* We'll define the page tables needed to identity map the first 8MB
@@ -80,40 +85,20 @@ void module_loader_main() {
     return;
   }
 
-  // scan through the M2IS for a module called KERNEL.ELF
-  m2is_tag_iterator iter = new_m2is_iterator(mis);
-  const m2is_tag *tag = m2is_iterator_next(&iter);
-  const char *mod = NULL;
-  while (tag != NULL) {
-    if (tag->type == M2IS_TYPE_MODULE) {
-      const m2is_module *modtag = (const m2is_module *)tag;
-      if (strcmp("KERNEL.ELF", modtag->string) == 0) {
-        printf("[+] Found KERNEL.ELF!\n");
-        mod = (char*)(uintptr_t)(modtag->mod_start);
-        break;
-      }
-    }
-    tag = m2is_iterator_next(&iter);
-  }
-
-  if (mod == NULL) {
-    term_set_fg(4);
-    printf("KERNEL.ELF not found!\n");
-    return;
-  }
-
   // verify that the module is an ELF file
-  if (!is_ELF(mod)) {
+  if (!is_ELF(kernel_elf_start)) {
     term_set_fg(4);
     printf("      Unknown format\n");
     return;
   }
+  printf("      Valid ELF!\n");
+
   // print the ELF info
   printf("      ELF %s-bit %s\n",
-         (get_ELF_class(mod) == EI_CLASS_32BIT) ? "32" : (get_ELF_class(mod) == EI_CLASS_64BIT ? "64" : "?""?"),
-         (get_ELF_endianness(mod) == EI_ENDIANNESS_LITTLE) ? "LE" : (get_ELF_endianness(mod) == EI_ENDIANNESS_BIG ? "BE" : "?""?")
+         (get_ELF_class(kernel_elf_start) == EI_CLASS_32BIT) ? "32" : (get_ELF_class(kernel_elf_start) == EI_CLASS_64BIT ? "64" : "?""?"),
+         (get_ELF_endianness(kernel_elf_start) == EI_ENDIANNESS_LITTLE) ? "LE" : (get_ELF_endianness(kernel_elf_start) == EI_ENDIANNESS_BIG ? "BE" : "?""?")
   );
-  if (get_ELF_endianness(mod) == EI_ENDIANNESS_BIG) {
+  if (get_ELF_endianness(kernel_elf_start) == EI_ENDIANNESS_BIG) {
     term_set_fg(4);
     /* term_print_string_at("BE", 17, PREV_LINE); */
     return;
@@ -126,7 +111,7 @@ void module_loader_main() {
   printf("[+] Bump allocator set up at 0x%08zx\n", (size_t)bump_malloc(0));
 
   // load the module
-  if (get_ELF_class(mod) == EI_CLASS_32BIT) {
+  if (get_ELF_class(kernel_elf_start) == EI_CLASS_32BIT) {
     term_set_fg(4);
     printf("[E] Module loader does not support 32-bit ELFs\n");
     return;
@@ -135,7 +120,7 @@ void module_loader_main() {
     setup_page_tables();
     printf("Done!\n");
     printf("[+] Mapping ELF... ");
-    int map_err = elf64_map_program_image(mod, page_level_4_tab);
+    int map_err = elf64_map_program_image(kernel_elf_start, page_level_4_tab);
     if (map_err == 0) {
       printf("Done!\n");
     } else {
@@ -195,7 +180,7 @@ void module_loader_main() {
 
     printf("[+] Jumping to long loader...\n");
     
-    entry.entry64 = get_elf64_entrypoint(mod);
+    entry.entry64 = get_elf64_entrypoint(kernel_elf_start);
 
     asm ("call switch_to_long" : : : );
   }

--- a/kernel/arch/x86_64/module_loader/module_loader.c
+++ b/kernel/arch/x86_64/module_loader/module_loader.c
@@ -85,7 +85,7 @@ void module_loader_main() {
     return;
   }
 
-  // verify that the module is an ELF file
+  // verify that the embedded ELF is actually an ELF file
   if (!is_ELF(kernel_elf_start)) {
     term_set_fg(4);
     printf("[!] Embedded ELF has unknown format!\n");
@@ -110,7 +110,7 @@ void module_loader_main() {
   bump_init(highest_addr + 1);
   printf("[+] Bump allocator set up at 0x%08zx\n", (size_t)bump_malloc(0));
 
-  // load the module
+  // map the ELF into memory
   if (get_ELF_class(kernel_elf_start) == EI_CLASS_32BIT) {
     term_set_fg(4);
     printf("[E] Module loader does not support 32-bit ELFs\n");

--- a/kernel/arch/x86_64/module_loader/module_loader.ld
+++ b/kernel/arch/x86_64/module_loader/module_loader.ld
@@ -36,9 +36,9 @@ SECTIONS
 	.rodata BLOCK(4K) : ALIGN(4K)
 	{
 		*(.rodata)
-                /* Copy in the kernel elf data */
-                . = ALIGN(4K);
-                *(.kernelelf)
+		/* Copy in the kernel elf data */
+		. = ALIGN(4K);
+		*(.kernelelf)
 	}
 
 	/* Read-write data (initialized) */

--- a/kernel/arch/x86_64/module_loader/module_loader.ld
+++ b/kernel/arch/x86_64/module_loader/module_loader.ld
@@ -36,6 +36,9 @@ SECTIONS
 	.rodata BLOCK(4K) : ALIGN(4K)
 	{
 		*(.rodata)
+                /* Copy in the kernel elf data */
+                . = ALIGN(4K);
+                *(.kernelelf)
 	}
 
 	/* Read-write data (initialized) */

--- a/make_sandbox
+++ b/make_sandbox
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 bwrap \
   --ro-bind /usr /usr \
   --ro-bind /bin /bin \
@@ -9,7 +11,7 @@ bwrap \
   --ro-bind /usr/share/ovmf /usr/share/ovmf \
   --tmpfs /tmp \
   --tmpfs ~/.cache/fontconfig \
-  --bind "$(pwd)" /sandbox \
+  --bind "${SCRIPT_DIR}" /sandbox \
   --dev-bind /dev/null /dev/null \
   --proc /proc \
   --chdir /sandbox \


### PR DESCRIPTION
Because the multiboot standard puts us in protected mode rather than long mode, a protected mode shim is needed to load the 64-bit kernel code, set up the page tables, enter long mode, and jump to the kernel. Loading of the kernel ELF is currently handled through multiboot's modules system: the loader parses the multiboot header, finds the module corresponding to the kernel ELF, then appropriately maps it in the page tables.

This PR changes the boot process by embedding the kernel ELF within the loader. Rather than using the module system, which mandates a (marginally) more complex `grub.cfg` and slightly more fragile boot process, embedding the kernel in the loader means the OS boots from a single ELF, which simplifies the filesystem layout and bootloader config and frees up the module system for later use.

The embedding is produced using `objcopy`, which copies the kernel ELF as raw binary data into an i386 ELF. This produces symbols marking the start, end, and size of the data, which can be referenced as `extern` variables from C. The exact symbol names are dependent on the file path passed to `objcopy`, so the symbol names are determined ahead of time using `sed`, and are then passed in at compile-time as preprocessor constants. To aid the data arrangement (i.e. ensure the kernel ELF is page-aligned), the `.data` section produced is renamed to `.kernelelf`, which makes it trivial to target this data in the linker script.

Closes #71.