### PR TITLE
Map framebuffer before setting lowest_free_addr

### DIFF
--- a/kernel/arch/x86_64/module_loader/bump_alloc.c
+++ b/kernel/arch/x86_64/module_loader/bump_alloc.c
@@ -1,16 +1,35 @@
 #include <stdbool.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <kernel/tty.h>
 #include "bump_alloc.h"
 
 typedef struct {
   size_t addr;
   bool init;
+  bool finished;
 } BumpAllocator;
 
 static BumpAllocator alloc = {0, false};
 
+static void bump_panic(const char *fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  term_set_fg(4);
+  vprintf(fmt, args);
+  __asm__ volatile (
+                    ".panic.hang:\n\r"
+                    "cli\n\r"
+                    "hlt\n\r"
+                    "jmp .panic.hang\n\r"
+                    : : :
+                    );
+}
+
 void bump_init(const size_t addr) {
   alloc.addr = addr;
   alloc.init = true;
+  alloc.finished = false;
 }
 
 void bump_align(const size_t boundary) {
@@ -21,8 +40,13 @@ void bump_align(const size_t boundary) {
 }
 
 void *bump_malloc(const size_t size) {
-  if (!alloc.init) return NULL;
+  if (!alloc.init) bump_panic("[!] Bump allocator used but not yet initialised!\n");
+  if (alloc.finished) bump_panic("[!] Bump allocator used after finish!\n");
   void* p = (void*)alloc.addr;
   alloc.addr += size;
   return p;
+}
+
+void bump_finish() {
+  alloc.finished = true;
 }

--- a/kernel/arch/x86_64/module_loader/bump_alloc.c
+++ b/kernel/arch/x86_64/module_loader/bump_alloc.c
@@ -7,7 +7,7 @@
 typedef struct {
   size_t addr;
   bool init;
-  bool finished;
+  bool locked;
 } BumpAllocator;
 
 static BumpAllocator alloc = {0, false};
@@ -29,7 +29,7 @@ static void bump_panic(const char *fmt, ...) {
 void bump_init(const size_t addr) {
   alloc.addr = addr;
   alloc.init = true;
-  alloc.finished = false;
+  alloc.locked = false;
 }
 
 void bump_align(const size_t boundary) {
@@ -41,12 +41,12 @@ void bump_align(const size_t boundary) {
 
 void *bump_malloc(const size_t size) {
   if (!alloc.init) bump_panic("[!] Bump allocator used but not yet initialised!\n");
-  if (alloc.finished && size != 0) bump_panic("[!] Bump allocator used after finish!\n");
+  if (alloc.locked && size != 0) bump_panic("[!] Bump allocator used after locking!\n");
   void* p = (void*)alloc.addr;
   alloc.addr += size;
   return p;
 }
 
-void bump_finish() {
-  alloc.finished = true;
+void bump_lock() {
+  alloc.locked = true;
 }

--- a/kernel/arch/x86_64/module_loader/bump_alloc.c
+++ b/kernel/arch/x86_64/module_loader/bump_alloc.c
@@ -41,7 +41,7 @@ void bump_align(const size_t boundary) {
 
 void *bump_malloc(const size_t size) {
   if (!alloc.init) bump_panic("[!] Bump allocator used but not yet initialised!\n");
-  if (alloc.finished) bump_panic("[!] Bump allocator used after finish!\n");
+  if (alloc.finished && size != 0) bump_panic("[!] Bump allocator used after finish!\n");
   void* p = (void*)alloc.addr;
   alloc.addr += size;
   return p;

--- a/kernel/arch/x86_64/module_loader/bump_alloc.h
+++ b/kernel/arch/x86_64/module_loader/bump_alloc.h
@@ -6,5 +6,6 @@
 void bump_init(const size_t addr);
 void* bump_malloc(const size_t size);
 void bump_align(const size_t boundary);
+void bump_finish();
 
 #endif

--- a/kernel/arch/x86_64/module_loader/bump_alloc.h
+++ b/kernel/arch/x86_64/module_loader/bump_alloc.h
@@ -6,6 +6,6 @@
 void bump_init(const size_t addr);
 void* bump_malloc(const size_t size);
 void bump_align(const size_t boundary);
-void bump_finish();
+void bump_lock();
 
 #endif

--- a/kernel/arch/x86_64/module_loader/module_loader.c
+++ b/kernel/arch/x86_64/module_loader/module_loader.c
@@ -150,8 +150,11 @@ void module_loader_main() {
     bs_init(&bootstruct);
     bootstruct.M2IS = (bs_ptr_t)((uintptr_t)mis);
     bootstruct.flags |= BS_FLAG_MIS;
+
+    // record the lowest free address and lock the bump allocator
     bootstruct.lowest_free_addr = (bs_ptr_t)((uintptr_t)bump_malloc(0));
     bootstruct.flags |= BS_FLAG_FREEADDR;
+    bump_finish();
 
     // if it returns true, then we successfully found the framebuffer
     // info in the MIS, and the bootstruct has been populated

--- a/kernel/arch/x86_64/module_loader/module_loader.c
+++ b/kernel/arch/x86_64/module_loader/module_loader.c
@@ -151,11 +151,6 @@ void module_loader_main() {
     bootstruct.M2IS = (bs_ptr_t)((uintptr_t)mis);
     bootstruct.flags |= BS_FLAG_MIS;
 
-    // record the lowest free address and lock the bump allocator
-    bootstruct.lowest_free_addr = (bs_ptr_t)((uintptr_t)bump_malloc(0));
-    bootstruct.flags |= BS_FLAG_FREEADDR;
-    bump_finish();
-
     // if it returns true, then we successfully found the framebuffer
     // info in the MIS, and the bootstruct has been populated
     if (bs_convert_fbinfo(&bootstruct, mis)) {
@@ -168,6 +163,12 @@ void module_loader_main() {
       // enable the bootstruct framebuffer tag
       bootstruct.flags |= BS_FLAG_FRAMEBUFFER;
     }
+
+    // record the lowest free address and lock the bump allocator
+    bootstruct.lowest_free_addr = (bs_ptr_t)((uintptr_t)bump_malloc(0));
+    bootstruct.flags |= BS_FLAG_FREEADDR;
+    bump_finish();
+
     bs_set_checksum(&bootstruct);
     printf("[+] Bootstruct built!\n");
     printf("      Flags: %#x\n"

--- a/kernel/arch/x86_64/module_loader/module_loader.c
+++ b/kernel/arch/x86_64/module_loader/module_loader.c
@@ -167,7 +167,7 @@ void module_loader_main() {
     // record the lowest free address and lock the bump allocator
     bootstruct.lowest_free_addr = (bs_ptr_t)((uintptr_t)bump_malloc(0));
     bootstruct.flags |= BS_FLAG_FREEADDR;
-    bump_finish();
+    bump_lock();
 
     bs_set_checksum(&bootstruct);
     printf("[+] Bootstruct built!\n");


### PR DESCRIPTION
See #80 for full details of the bug.

This PR rearranges the code so that the framebuffer is mapped before setting `lowest_free_addr`. This means `lowest_free_addr` is actually correct, and prevents the page tables for the framebuffer from being overwritten the first time the PMM yields a page.

Also introduces `bump_lock` and `bump_panic`. The former allows the bump allocator to be locked once you're done with it -- in this case, once you've written `lowest_free_addr` -- and will call the latter to print an error message and halt the boot process if the bump allocator is used after it is locked. Once locked, the bump allocator cannot be unlocked without reinitialising it with `bump_init`. This should help to prevent regressions.

Closes #80.